### PR TITLE
Macros

### DIFF
--- a/asm/macro.asm
+++ b/asm/macro.asm
@@ -3,6 +3,15 @@
         imul    %1, rcx
 %endmacro
 
+%macro print 1
+        mov     rsi, %1
+        movsx   rdx, DWORD [%1-4]
+        mov     rdi, 1
+        mov     rax, 1
+        syscall
+        xor     rax, rax
+%endmacro
+
 %macro concat 1
         mov     r12, %1
         pop     r14

--- a/asm/macro.asm
+++ b/asm/macro.asm
@@ -1,4 +1,27 @@
-%macro multiply 2
-        pop     %2
-        imul    %1, %2
+%macro multiply 1
+        pop     rcx
+        imul    %1, rcx
+%endmacro
+
+%macro concat 1
+        mov     r12, %1
+        pop     r14
+        movsx   rax, DWORD [r12-4]
+        movsx   rcx, DWORD [r14-4]
+        add     rax, rcx
+        add     rax, 4
+        call    alloc
+        movsx   rbx, DWORD [r12-4]
+        movsx   rcx, DWORD [r14-4]
+        add     rbx, rcx
+        mov     [rax], DWORD ebx
+        add     rax, 4
+        mov     rdi, rax
+        mov     rsi, r12
+        movsx   rcx, DWORD [r12-4]
+        cld
+        rep     movsb
+        mov     rsi, r14
+        movsx   rcx, DWORD [r14-4]
+        rep     movsb
 %endmacro

--- a/asm/macro.asm
+++ b/asm/macro.asm
@@ -1,0 +1,4 @@
+%macro multiply 2
+        pop     %2
+        imul    %1, %2
+%endmacro

--- a/asm/macro.asm
+++ b/asm/macro.asm
@@ -34,3 +34,15 @@
         movsx   rcx, DWORD [r14-4]
         rep     movsb
 %endmacro
+
+%macro compare 1
+    pop     rcx
+    compare %1, rcx
+%endmacro
+
+%macro compare 2
+    mov     rbx, rax
+    xor     rax, rax
+    cmp     rbx, %2
+    %1      al
+%endmacro

--- a/lib/actions.rb
+++ b/lib/actions.rb
@@ -25,7 +25,7 @@ class Action
 
   @actions[:!] = proc { compare_with('sete', 0) }
 
-  @actions[:*] = proc { 'multiply rax, rcx'.asm }
+  @actions[:*] = proc { 'multiply rax'.asm }
 
   @actions[:/] = proc { division }
 
@@ -45,30 +45,7 @@ class Action
     ASM
   end
 
-  @actions[:concat] = proc do
-    <<-ASM
-    mov     #{Register[:"12"]}, #{Register[:ax]}
-    pop     #{Register[:"14"]}
-    movsx   #{Register[:ax]}, DWORD [#{Register[:"12"]}-4]
-    movsx   #{Register[:cx]}, DWORD [#{Register[:"14"]}-4]
-    add     #{Register[:ax]}, #{Register[:cx]}
-    add     #{Register[:ax]}, 4
-    call    alloc
-    movsx   #{Register[:bx]}, DWORD [#{Register[:"12"]}-4]
-    movsx   #{Register[:cx]}, DWORD [#{Register[:"14"]}-4]
-    add     #{Register[:bx]}, #{Register[:cx]}
-    mov     [#{Register[:ax]}], DWORD #{Register[:bx].r32}
-    add     #{Register[:ax]}, 4
-    mov     #{Register[:di]}, #{Register[:ax]}
-    mov     #{Register[:si]}, #{Register[:"12"]}
-    movsx   #{Register[:cx]}, DWORD [#{Register[:"12"]}-4]
-    cld
-    rep     movsb
-    mov     #{Register[:si]}, #{Register[:"14"]}
-    movsx   #{Register[:cx]}, DWORD [#{Register[:"14"]}-4]
-    rep     movsb
-    ASM
-  end
+  @actions[:concat] = proc { "concat #{Register[:ax]}".asm }
 
   class << self
     def [](name)

--- a/lib/actions.rb
+++ b/lib/actions.rb
@@ -34,16 +34,7 @@ class Action
       .concat "mov #{Register[:ax]}, #{Register[:dx]}".asm
   end
 
-  @actions[:print] = proc do
-    <<-ASM
-    mov     #{Register[:si]}, #{Register[:ax]}
-    movsx   #{Register[:dx]}, DWORD [#{Register[:ax]}-4]
-    mov     #{Register[:di]}, 1
-    mov     #{Register[:ax]}, 1
-    syscall
-    xor     #{Register[:ax]}, #{Register[:ax]}
-    ASM
-  end
+  @actions[:print] = proc { "print #{Register[:ax]}".asm }
 
   @actions[:concat] = proc { "concat #{Register[:ax]}".asm }
 

--- a/lib/actions.rb
+++ b/lib/actions.rb
@@ -25,7 +25,7 @@ class Action
 
   @actions[:!] = proc { compare_with('sete', 0) }
 
-  @actions[:*] = proc { arithmacy 'imul' }
+  @actions[:*] = proc { 'multiply rax, rcx'.asm }
 
   @actions[:/] = proc { division }
 

--- a/lib/actions.rb
+++ b/lib/actions.rb
@@ -13,17 +13,17 @@ class Action
 
   @actions[:-] = proc { arithmacy 'sub' }
 
-  @actions[:"="] = proc { compare 'sete' }
+  @actions[:"="] = proc { 'compare sete'.asm }
 
-  @actions[:<] = proc { compare 'setl' }
+  @actions[:<] = proc { 'compare setl'.asm }
 
-  @actions[:<=] = proc { compare 'setle' }
+  @actions[:<=] = proc { 'compare setle'.asm }
 
-  @actions[:>] = proc { compare 'setg' }
+  @actions[:>] = proc { 'compare setg'.asm }
 
-  @actions[:>=] = proc { compare 'setge' }
+  @actions[:>=] = proc { 'compare setge'.asm }
 
-  @actions[:!] = proc { compare_with('sete', 0) }
+  @actions[:!] = proc { 'compare sete, 0'.asm }
 
   @actions[:*] = proc { 'multiply rax'.asm }
 
@@ -44,17 +44,6 @@ class Action
     end
 
     private
-
-    def compare(comparison)
-      "pop #{Register[:cx]}".asm << compare_with(comparison, Register[:cx])
-    end
-
-    def compare_with(comparison, other)
-      ''.concat "mov #{Register[:bx]}, #{Register[:ax]}".asm
-        .concat "xor #{Register[:ax]}, #{Register[:ax]}".asm
-        .concat "cmp #{Register[:bx]}, #{other}".asm
-        .concat "#{comparison} #{Register[:ax].r8}".asm
-    end
 
     def arithmacy(operation)
       ''.concat "pop #{Register[:cx]}".asm

--- a/slwslvr
+++ b/slwslvr
@@ -46,7 +46,7 @@ linking_file = filename + '.o'
 
 File.open(assembly_file, 'w') { |f| f.write(generator.code) }
 
-assembly_compiler = 'nasm -f elf64'
+assembly_compiler = 'nasm -f elf64 -p asm/macro.asm'
 mem_manager = 'asm/memory-manager.o'
 
 if system("#{assembly_compiler} #{assembly_file}")

--- a/spec/equal_comp_spec.rb
+++ b/spec/equal_comp_spec.rb
@@ -29,8 +29,7 @@ describe 'simple_comparison1.sag' do
         mov     rax, 3
         push    rax
         mov     rax, 3
-        pop     rcx
-    #{CodeGen.compare 'rcx'}
+    #{CodeGen.compare 'sete'}
     #{CodeGen.exit 'rax'}
   ASM
 end

--- a/spec/generator/code_generation.rb
+++ b/spec/generator/code_generation.rb
@@ -8,12 +8,9 @@ class CodeGen
       .chomp
   end
 
-  def self.compare(against, opcode = 'sete')
+  def self.compare(opcode, against = nil)
     <<-ASM
-    mov     rbx, rax
-    xor     rax, rax
-    cmp     rbx, #{against}
-    #{opcode.ljust(8)}al
+    compare #{opcode}#{against.nil? ? nil : ", #{against}"}
     ASM
       .chomp
   end

--- a/spec/generator/code_generation.rb
+++ b/spec/generator/code_generation.rb
@@ -35,12 +35,7 @@ class CodeGen
 
   def self.print(str_ptr)
     <<-ASM
-    mov     rsi, #{str_ptr}
-    movsx   rdx, DWORD [#{str_ptr}-4]
-    mov     rdi, 1
-    mov     rax, 1
-    syscall
-    xor     rax, rax
+    print   #{str_ptr}
     ASM
       .chomp
   end

--- a/spec/generator/code_generation.rb
+++ b/spec/generator/code_generation.rb
@@ -26,9 +26,9 @@ class CodeGen
       .chomp
   end
 
-  def self.multiply reg
+  def self.multiply(reg)
     <<-ASM
-    multiply #{reg}, rcx
+    multiply #{reg}
     ASM
       .chomp
   end
@@ -47,26 +47,7 @@ class CodeGen
 
   def self.concat
     <<-ASM
-    mov     r12, rax
-    pop     r14
-    movsx   rax, DWORD [r12-4]
-    movsx   rcx, DWORD [r14-4]
-    add     rax, rcx
-    add     rax, 4
-    call    alloc
-    movsx   rbx, DWORD [r12-4]
-    movsx   rcx, DWORD [r14-4]
-    add     rbx, rcx
-    mov     [rax], DWORD ebx
-    add     rax, 4
-    mov     rdi, rax
-    mov     rsi, r12
-    movsx   rcx, DWORD [r12-4]
-    cld
-    rep     movsb
-    mov     rsi, r14
-    movsx   rcx, DWORD [r14-4]
-    rep     movsb
+    concat  rax
     ASM
       .chomp
   end

--- a/spec/generator/code_generation.rb
+++ b/spec/generator/code_generation.rb
@@ -9,10 +9,7 @@ class CodeGen
   end
 
   def self.compare(opcode, against = nil)
-    <<-ASM
-    compare #{opcode}#{against.nil? ? nil : ", #{against}"}
-    ASM
-      .chomp
+    "    compare #{opcode}#{against.nil? ? nil : ", #{against}"}"
   end
 
   def self.externs
@@ -24,23 +21,14 @@ class CodeGen
   end
 
   def self.multiply(reg)
-    <<-ASM
-    multiply #{reg}
-    ASM
-      .chomp
+    "    multiply #{reg}"
   end
 
   def self.print(str_ptr)
-    <<-ASM
-    print   #{str_ptr}
-    ASM
-      .chomp
+    "    print   #{str_ptr}"
   end
 
   def self.concat
-    <<-ASM
-    concat  rax
-    ASM
-      .chomp
+    '    concat  rax'
   end
 end

--- a/spec/generator/code_generation.rb
+++ b/spec/generator/code_generation.rb
@@ -26,6 +26,13 @@ class CodeGen
       .chomp
   end
 
+  def self.multiply reg
+    <<-ASM
+    multiply #{reg}, rcx
+    ASM
+      .chomp
+  end
+
   def self.print(str_ptr)
     <<-ASM
     mov     rsi, #{str_ptr}

--- a/spec/greater_than_spec.rb
+++ b/spec/greater_than_spec.rb
@@ -29,8 +29,7 @@ describe 'greater_than1.sag' do
         mov     rax, 3
         push    rax
         mov     rax, 4
-        pop     rcx
-    #{CodeGen.compare 'rcx', 'setg'}
+    #{CodeGen.compare 'setg'}
     #{CodeGen.exit 'rax'}
   ASM
 end
@@ -51,8 +50,7 @@ describe 'greater_than_equal1.sag' do
         mov     rax, 3
         push    rax
         mov     rax, 4
-        pop     rcx
-    #{CodeGen.compare 'rcx', 'setge'}
+    #{CodeGen.compare 'setge'}
     #{CodeGen.exit 'rax'}
   ASM
 end

--- a/spec/less_than_spec.rb
+++ b/spec/less_than_spec.rb
@@ -29,8 +29,7 @@ describe 'less_than_equal1.sag' do
         mov     rax, 6
         push    rax
         mov     rax, 5
-        pop     rcx
-    #{CodeGen.compare 'rcx', 'setle'}
+    #{CodeGen.compare 'setle'}
     #{CodeGen.exit 'rax'}
   ASM
 end
@@ -51,8 +50,7 @@ describe 'less_than1.sag' do
         mov     rax, 2
         push    rax
         mov     rax, 1
-        pop     rcx
-    #{CodeGen.compare 'rcx', 'setl'}
+    #{CodeGen.compare 'setl'}
     #{CodeGen.exit 'rax'}
   ASM
 end

--- a/spec/logical_param_match_spec.rb
+++ b/spec/logical_param_match_spec.rb
@@ -206,8 +206,7 @@ describe 'logical_param_matching9.sag' do
         mov     rax, 5
         push    rax
         mov     rax, [rbp+16]
-        pop     rcx
-    #{CodeGen.compare 'rcx', 'setg'}
+    #{CodeGen.compare 'setg'}
         cmp     rax, 1
         jne     _limit1
         mov     rax, 0

--- a/spec/match_function_spec.rb
+++ b/spec/match_function_spec.rb
@@ -282,8 +282,7 @@ describe 'params_matching2.sag' do
         mov     rax, [rbp+24]
         push    rax
         mov     rax, [rbp+16]
-        pop     rcx
-        imul    rax, rcx
+    #{CodeGen.multiply 'rax'}
     _testdone:
         mov     rsp, rbp
         pop     rbp

--- a/spec/multiplication_spec.rb
+++ b/spec/multiplication_spec.rb
@@ -42,8 +42,7 @@ describe 'multiplication1.sag' do
         mov     rax, 6
         push    rax
         mov     rax, 3
-        pop     rcx
-        imul    rax, rcx
+    #{CodeGen.multiply 'rax'}
     #{CodeGen.exit 'rax'}
   ASM
 end

--- a/spec/negate_bool_spec.rb
+++ b/spec/negate_bool_spec.rb
@@ -47,9 +47,8 @@ describe 'not1.sag' do
         mov     rax, 8
         push    rax
         mov     rax, 4
-        pop     rcx
-    #{CodeGen.compare 'rcx'}
-    #{CodeGen.compare '0'}
+    #{CodeGen.compare 'sete'}
+    #{CodeGen.compare 'sete', '0'}
     #{CodeGen.exit 'rax'}
   ASM
 end

--- a/spec/print_string_spec.rb
+++ b/spec/print_string_spec.rb
@@ -115,11 +115,7 @@ describe 'strings2.sag' do
         mov     rax, 20
         push    rax
         mov     rax, [rbp+16]
-        pop     rcx
-        mov     rbx, rax
-        xor     rax, rax
-        cmp     rbx, rcx
-        setl    al
+    #{CodeGen.compare 'setl'}
         cmp     rax, 1
         jne     _enough1
         mov     rax, str0
@@ -129,11 +125,7 @@ describe 'strings2.sag' do
         mov     rax, 30
         push    rax
         mov     rax, [rbp+16]
-        pop     rcx
-        mov     rbx, rax
-        xor     rax, rax
-        cmp     rbx, rcx
-        setl    al
+    #{CodeGen.compare 'setl'}
         cmp     rax, 1
         jne     _enough2
         mov     rax, str1


### PR DESCRIPTION
An initial example of how using macros could make it easy to refactor assembly code. Generated assembly need only reference the macro, so changes to the details of how the assembly works with the macro need only be made in one place. The correct functionality of the macros continues to be tested by the compiling test which will fail if the macros aren't behaving correctly.